### PR TITLE
Fix/md-converter

### DIFF
--- a/src/components/paper/index.tsx
+++ b/src/components/paper/index.tsx
@@ -72,7 +72,9 @@ export const Paper: FC<Ipaper> = ({
         src={data.image}
         alt={`Превью статьи: ${data.title}`}
       />
-      <p className={styles.paper__text}>{converMdToHTML(data.text, false)}</p>
+      <div className={styles.paper__text}>
+        {converMdToHTML(data.text, false)}
+      </div>
 
       <div className={styles.paper__buttons}>
         {/* в фигме дизайнеры указали, что сохранить только для статей */}

--- a/src/components/paper/styles.module.scss
+++ b/src/components/paper/styles.module.scss
@@ -13,21 +13,18 @@
     @extend %text-size-medium-semibold;
     color: $color-neutral-400;
     margin-bottom: 20px;
-    padding: 0;
   }
 
   &__header {
     @extend %heading-size-medium;
     color: $color-neutral-900;
     margin-bottom: 24px;
-    padding: 0;
   }
 
   &__annotation {
     @extend %text-size-large;
     color: $color-neutral-700;
     margin-bottom: 26px;
-    padding: 0;
   }
 
   &__info {
@@ -40,10 +37,6 @@
 
   &__clock {
     margin-right: 4px;
-  }
-
-  &__time {
-    margin: 0;
   }
 
   &__dot {
@@ -78,6 +71,15 @@
     @extend %text-article;
     color: $color-neutral-900;
     margin: 0 auto 32px;
+
+    h3,
+    p {
+      margin-bottom: 24px;
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 
   &__buttons {
@@ -150,7 +152,6 @@
 
     span {
       @extend %text-size-medium-semibold;
-      justify-content: center;
     }
   }
 }

--- a/src/utils/functions/convert-md-to-html.ts
+++ b/src/utils/functions/convert-md-to-html.ts
@@ -8,6 +8,8 @@ const marked = new Marked({
   gfm: true, // If true, use approved GitHub Flavored Markdown (GFM) specification.
   silent: false,
   breaks: true,
+  mangle: false,
+  headerIds: false,
 });
 
 const purifySettings = {

--- a/src/utils/functions/convert-md-to-html.ts
+++ b/src/utils/functions/convert-md-to-html.ts
@@ -34,9 +34,13 @@ export const converMdToHTML = (data: string, isAnnotation: boolean) => {
 
   preparedMD = marked.parse(data);
   if (typeof preparedMD === 'string') {
-    preparedMD = isAnnotation
-      ? preparedMD.replace(/h[1-6]/g, 'p')
-      : preparedMD.replace(/h[1-6]/g, 'h3');
+    if (isAnnotation) {
+      preparedMD = preparedMD.replace(/h[1-6]/g, 'span');
+      preparedMD = preparedMD.replace(/p>/g, 'span>');
+    } else {
+      preparedMD = preparedMD.replace(/h[1-6]/g, 'h3');
+    }
+
     cleanData = DOMPurify.sanitize(preparedMD, purifySettings);
     finishData = parse(cleanData);
     return finishData;


### PR DESCRIPTION
Исправлены ошибки верстки и предупреждения, пример ошибок:
![photo_2023-08-06_03-46-01](https://github.com/Medical-Information/medical-information-frontend/assets/76571113/62a642cf-cf19-4465-935f-19410418d82c)

Также в разметку статьи и новости добавлены отступы для параграфов и заголовков в основном тексте, ранее весь текст был одним целым, теперь результат по стилям больше похож на правду из макета

