### PR TITLE
Refactor/article-news-pages

### DIFF
--- a/src/components/articles-preview-small/styles.module.scss
+++ b/src/components/articles-preview-small/styles.module.scss
@@ -2,7 +2,7 @@
 
 .articles {
   max-width: 1208px;
-  margin: 0 auto;
+  // margin: 0 auto;
   padding: 0;
 
   &__header {

--- a/src/components/news-preview-small/styles.module.scss
+++ b/src/components/news-preview-small/styles.module.scss
@@ -2,7 +2,7 @@
 
 .news {
   max-width: 1208px;
-  margin: 0 auto;
+  // margin: 0 auto;
   padding: 0;
 
   &__header {

--- a/src/components/paper/index.tsx
+++ b/src/components/paper/index.tsx
@@ -10,7 +10,7 @@ import { DotIcon } from 'shared/icons/dot-icon';
 import { ClockIcon } from 'shared/icons/clock-icon';
 import { ViewsIcon } from 'shared/icons/views-icon';
 
-import { ForwardIcon } from 'shared/icons/forward-icon';
+// import { ForwardIcon } from 'shared/icons/forward-icon';
 import { BookmarkIcon } from 'shared/icons/bookmark-icon';
 import { CommentsIcon } from 'shared/icons/comments-icon';
 
@@ -39,7 +39,7 @@ export const Paper: FC<Ipaper> = ({
 
   const handleAddBookmark = () => null;
   const handleAddComment = () => null;
-  const handleForward = () => null;
+  // const handleForward = () => null;
 
   return (
     <article className={styles.paper} id={data.id}>
@@ -77,7 +77,7 @@ export const Paper: FC<Ipaper> = ({
       </div>
 
       <div className={styles.paper__buttons}>
-        {/* в фигме дизайнеры указали, что сохранить только для статей */}
+        {/* сохранить только для статей */}
         {!isNews && (
           <ButtonWithIconThree
             icon={
@@ -92,14 +92,15 @@ export const Paper: FC<Ipaper> = ({
             extraClass={styles.paper__button}
           />
         )}
-
-        <ButtonWithIconThree
+        {/* поделиться в текущем релизе не используется ни для статьи, ни для новости */}
+        {/* <ButtonWithIconThree
           icon={
             <ForwardIcon color="gray" size="32" className={styles.forward} />
           }
           onClick={handleForward}
           extraClass={styles.paper__button}
-        />
+        /> */}
+
         <ButtonWithIconThree
           icon={
             <CommentsIcon color="gray" size="24" className={styles.forward} />
@@ -118,16 +119,18 @@ export const Paper: FC<Ipaper> = ({
         >{`${data.author?.first_name} ${data.author?.last_name}`}</Link>
       </div>
 
-      {data.tags ? (
+      {data.tags && !isNews ? (
         <div className={styles.paper__additional}>
           <p className={styles.paper__additional_text}>Теги:</p>
           <ul className={styles.paper__tags}>
             {data?.tags.map((tag, idx) => (
               <li key={idx}>
                 <Button
+                  model="secondary"
                   label={tag.name}
                   id={tag.pk}
-                  color="blue"
+                  color="white"
+                  hasBorder
                   size="small"
                   extraClass={styles.paper__tag}
                 />

--- a/src/components/paper/styles.module.scss
+++ b/src/components/paper/styles.module.scss
@@ -145,13 +145,7 @@
   }
 
   &__tag {
-    // width: 102px;
     height: 40px;
     padding: 8px 24px;
-    background-color: $color-brand-primary-700;
-
-    span {
-      @extend %text-size-medium-semibold;
-    }
   }
 }

--- a/src/pages/article/index.tsx
+++ b/src/pages/article/index.tsx
@@ -27,17 +27,24 @@ export const Article: FC = () => {
   const errResponse = response.error || {};
   const errCode = 'status' in errResponse ? errResponse.status : null;
 
-  // теги
+  // все теги
   const { data: tags = [] } = useGetRootsTagsQuery();
   const newsTag = tags.find((tag) => tag.name === 'Новости');
 
   // теги по конкретной статье, исключаем новости
-  const materialTagsQuery = `${article?.tags
-    ?.map((tag) => `tags=${tag.pk}`)
-    .join('&')}&tags_exclude=${newsTag?.pk}`;
+  // есть ли у статьи теги
+  const tagsQuery =
+    article?.tags && article?.tags.map((tag) => `tags=${tag.pk}`).join('&');
+  // есть\нет теги исключений
+  const tagsExclude = newsTag?.pk ? `tags_exclude=${newsTag?.pk}` : '';
+
+  const materialTagsQuery = tagsQuery
+    ? `${tagsQuery}&${tagsExclude}`
+    : tagsExclude;
 
   const { data } = useGetArticlesbyTagsQuery(materialTagsQuery);
-  console.log(data);
+
+  const materials = data?.results.filter((item) => item.id !== article?.id);
 
   useScrollToTop();
 
@@ -49,9 +56,9 @@ export const Article: FC = () => {
         <section className={styles.article} aria-label="Страница статьи">
           <div className={styles.article__container}>
             <Paper data={article} isNews={false} />
-            {data ? (
+            {materials?.length ? (
               <ArticlesPreviewSmall
-                data={data.results}
+                data={materials}
                 route={routes.articles.route}
               />
             ) : null}

--- a/src/pages/article/index.tsx
+++ b/src/pages/article/index.tsx
@@ -13,11 +13,10 @@ import { ServerErrorPage } from 'pages/error-page/serverErrorPage';
 import routes from 'utils/routes';
 import { useGetRootsTagsQuery } from 'services/features/tags/api';
 import {
-  useGetAllArticlesQuery,
+  useGetArticlesbyTagsQuery,
   useGetMaterialByIdQuery,
 } from 'services/features/information-material/api';
 import { useScrollToTop } from 'hooks/useScrollToTop';
-
 import styles from './styles.module.scss';
 
 export const Article: FC = () => {
@@ -28,16 +27,17 @@ export const Article: FC = () => {
   const errResponse = response.error || {};
   const errCode = 'status' in errResponse ? errResponse.status : null;
 
-  // TODO: решить вопрос с запросом двух статей по тегам для превью
-  // const currentTags = article.tags
-  // переписать запрос с использованием тегов, пока беру любые статьи
-
-  // Получаем список всех тегов
+  // теги
   const { data: tags = [] } = useGetRootsTagsQuery();
-  // Находим тег новости
   const newsTag = tags.find((tag) => tag.name === 'Новости');
-  // Получаем список всех статей
-  const { data } = useGetAllArticlesQuery(newsTag?.pk, { skip: !newsTag });
+
+  // теги по конкретной статье, исключаем новости
+  const materialTagsQuery = `${article?.tags
+    ?.map((tag) => `tags=${tag.pk}`)
+    .join('&')}&tags_exclude=${newsTag?.pk}`;
+
+  const { data } = useGetArticlesbyTagsQuery(materialTagsQuery);
+  console.log(data);
 
   useScrollToTop();
 

--- a/src/services/features/information-material/api.ts
+++ b/src/services/features/information-material/api.ts
@@ -27,6 +27,10 @@ export const informationMaterialApi = createApi({
     getMaterialById: builder.query<TArticle, string | undefined>({
       query: (id) => `${api.endpoints.articles.base}/${id}`,
     }),
+
+    getArticlesbyTags: builder.query<any, string | undefined>({
+      query: (tagsQuery) => `${api.endpoints.articles.base}/?${tagsQuery}`,
+    }),
   }),
 });
 
@@ -54,4 +58,5 @@ export const {
   useGetAllArticlesQuery,
   useGetAllNewsQuery,
   useGetMaterialByIdQuery,
+  useGetArticlesbyTagsQuery,
 } = informationMaterialApi;

--- a/src/services/features/information-material/api.ts
+++ b/src/services/features/information-material/api.ts
@@ -28,7 +28,10 @@ export const informationMaterialApi = createApi({
       query: (id) => `${api.endpoints.articles.base}/${id}`,
     }),
 
-    getArticlesbyTags: builder.query<any, string | undefined>({
+    getArticlesbyTags: builder.query<
+      TGetInformationMaterialResponse,
+      string | undefined
+    >({
       query: (tagsQuery) => `${api.endpoints.articles.base}/?${tagsQuery}`,
     }),
   }),

--- a/src/utils/previewSmall/index.ts
+++ b/src/utils/previewSmall/index.ts
@@ -5,15 +5,6 @@ export const generateSmallPreview = (
   maxNumberWindow: number,
   id: string
 ) => {
-  const randomData: TArticle[] = [];
-
-  while (randomData.length < maxNumberWindow) {
-    const randomN = Math.floor(Math.random() * data.length);
-    const randomItem = data[randomN];
-    if (!randomData.includes(randomItem) && randomItem.id !== id) {
-      randomData.push(randomItem);
-    }
-  }
-
-  return randomData;
+  const dataArr = data.filter((item) => item.id !== id);
+  return dataArr.slice(0, maxNumberWindow);
 };


### PR DESCRIPTION
- [x] Убрать теги и иконку поделиться со страницы новости.
- [x] Убрать иконку поделиться со страницы статьи.
- [x] Изменить дизайн тегов согласно макету на странице статьи.
- [x] Настроить логику блока "еще по этой теме". Необходимо найти статьи по тегам основной статьи и вывести 2 штуки. Здесь предлагаю сделать так - искать статьи по специализации. То есть по корневому тегу "специализации". К примеру если у статьи есть тег "генетика", то делаем запрос на сервер с тегом "генетика" и оттуда вытягиваем 2 статьи. Делаем через RTQ query.

Для превью статей сделала поиск по всем тегам сразу: он затрагивает специализацию и подтягивает еще что-нибудь интересное по другим тегам, если совсем статей нет по тематике специализации, запрос оформлен в RTK query