### PR TITLE
feat(hocs/withprotectedroute): protect routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,42 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect } from 'react';
-import { Route, Routes } from 'react-router-dom';
-import MainPage from 'pages/main-page/main-page';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { useAppDispatch } from 'services/app/hooks';
-import { getUserPersonalData } from 'services/features/user/api';
+
+import { OnlyAuth, OnlyUnAuth } from 'hocs/withProtectedRoute';
+
+import MainPage from 'pages/main-page/main-page';
 import NewsPreviewPage from 'pages/news-preview-page/news-preview-page';
-import { AuthorsPage } from 'pages/authors/authors';
-import ArticlesPreviewPage from 'pages/articles-preview-page/articles-preview-page';
-import SignUpPage from 'pages/sign-up/sign-up';
-import { SignUpActivationPage } from 'pages/sign-up-activation/sign-up-activation';
-import SignInPage from 'pages/sign-in/sign-in';
-import { ResetPasswordPage } from 'pages/reset-password/reset-password';
-import { ResetPasswordConfirmationPage } from 'pages/reset-password-confirmation/reset-password-confirmation';
-import { NotFoundPage } from 'pages/error-page/notFoundPage';
-import AboutPage from 'pages/about-us/about-us';
-import routes from 'utils/routes';
-import { Article } from 'pages/article';
 import { News } from 'pages/news';
+import ArticlesPreviewPage from 'pages/articles-preview-page/articles-preview-page';
+import { Article } from 'pages/article';
+import AboutPage from 'pages/about-us/about-us';
+import { AuthorsPage } from 'pages/authors/authors';
+
 import ProfilePage from 'pages/profile/profile-page';
 import UserProfile from 'components/user-profile/user-profile';
 import { FavoritesPage } from 'pages/favorites/favorites';
 import { CreatingAnArticlePage } from 'pages/creating-an-article/creating-an-article';
 
+import SignUpPage from 'pages/sign-up/sign-up';
+import { SignUpActivationPage } from 'pages/sign-up-activation/sign-up-activation';
+
+import SignInPage from 'pages/sign-in/sign-in';
+
+import { ResetPasswordPage } from 'pages/reset-password/reset-password';
+import { ResetPasswordConfirmationPage } from 'pages/reset-password-confirmation/reset-password-confirmation';
+import { NotFoundPage } from 'pages/error-page/notFoundPage';
+
+import { getUserPersonalData } from 'services/features/user/api';
+import { checkUserAuth } from 'services/features/user/slice';
+
+import routes from 'utils/routes';
+
 function App() {
+  const location = useLocation();
   const dispatch = useAppDispatch();
+
+  const background = location.state?.background;
 
   useEffect(() => {
     const token: string | null | undefined = localStorage.getItem('auth_token');
@@ -31,40 +44,53 @@ function App() {
     if (token) {
       dispatch(getUserPersonalData(token));
     }
+
+    dispatch(checkUserAuth());
   }, []); // eslint-disable-line
 
   return (
-    <Routes>
+    <Routes location={background || location}>
       <Route path={routes.home} element={<MainPage />} />
+
       <Route path={routes.news.route} element={<NewsPreviewPage />} />
       <Route path={`${routes.news.route}/:id`} element={<News />} />
 
       <Route path={routes.articles.route} element={<ArticlesPreviewPage />} />
       <Route path={`${routes.articles.route}/:id`} element={<Article />} />
 
-      <Route path={routes.podcasts.route} element={<NotFoundPage />} />
-      <Route path={routes.drugs.route} element={<NotFoundPage />} />
-      <Route path={routes.doctorQuestion.route} element={<NotFoundPage />} />
       <Route path={routes.about.route} element={<AboutPage />} />
       <Route path={routes.authors.route} element={<AuthorsPage />} />
 
-      <Route path={routes.signup} element={<SignUpPage />} />
       <Route
-        path={routes.signupActivation}
-        element={<SignUpActivationPage />}
-      />
-      <Route path={routes.signin} element={<SignInPage />} />
-      <Route path={routes.password.reset} element={<ResetPasswordPage />} />
-      <Route
-        path={routes.password.resetConfirmation}
-        element={<ResetPasswordConfirmationPage />}
-      />
-
-      <Route path={`${routes.profile}/*`} element={<ProfilePage />}>
+        path={`${routes.profile}/*`}
+        element={<OnlyAuth component={<ProfilePage />} />}
+      >
         <Route index element={<UserProfile />} />
         <Route path={routes.favorites} element={<FavoritesPage />} />
         <Route path={routes.publication} element={<CreatingAnArticlePage />} />
       </Route>
+
+      <Route
+        path={routes.signup}
+        element={<OnlyUnAuth component={<SignUpPage />} />}
+      />
+      <Route
+        path={routes.signupActivation}
+        element={<OnlyUnAuth component={<SignUpActivationPage />} />}
+      />
+
+      <Route
+        path={routes.signin}
+        element={<OnlyUnAuth component={<SignInPage />} />}
+      />
+      <Route
+        path={routes.password.reset}
+        element={<OnlyUnAuth component={<ResetPasswordPage />} />}
+      />
+      <Route
+        path={routes.password.resetConfirmation}
+        element={<OnlyUnAuth component={<ResetPasswordConfirmationPage />} />}
+      />
 
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/src/hocs/withProtectedRoute.tsx
+++ b/src/hocs/withProtectedRoute.tsx
@@ -1,0 +1,81 @@
+import { FC, ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAppSelector } from 'services/app/hooks';
+import {
+  isUserAuthChecked,
+  showUserPersonalData,
+} from 'services/features/user/selectors';
+import routes from 'utils/routes';
+
+interface IWithProtectedRouteProps {
+  component: ReactElement;
+  onlyUnAuth?: boolean;
+}
+
+interface IOnlyUnAuthProps {
+  component: ReactElement;
+}
+
+const WithProtectedRoute: FC<IWithProtectedRouteProps> = ({
+  component,
+  onlyUnAuth = false,
+}) => {
+  const isAuthChecked = useAppSelector(isUserAuthChecked);
+  const { user } = useAppSelector(showUserPersonalData);
+  const location = useLocation();
+
+  const { from } = location.state || { from: { pathname: routes.home } };
+
+  const isRouteEmailActivation = location.pathname.endsWith(
+    routes.signupActivation
+  );
+
+  let hasEmailActivation = localStorage.getItem('hasEmailActivation');
+
+  if (hasEmailActivation) {
+    hasEmailActivation = JSON.parse(hasEmailActivation);
+  }
+
+  const isRouteResetPasswordConfirmation = location.pathname.endsWith(
+    routes.password.resetConfirmation
+  );
+
+  let hasResetPasswordActivation = localStorage.getItem(
+    'hasResetPasswordActivation'
+  );
+
+  if (hasResetPasswordActivation) {
+    hasResetPasswordActivation = JSON.parse(hasResetPasswordActivation);
+  }
+
+  if (!isAuthChecked) return null;
+
+  if (onlyUnAuth && user) {
+    return <Navigate to={from} />;
+  }
+
+  if (onlyUnAuth && !user && isRouteEmailActivation && !hasEmailActivation) {
+    return <Navigate to={routes.signup} />;
+  }
+
+  if (
+    onlyUnAuth &&
+    !user &&
+    isRouteResetPasswordConfirmation &&
+    !hasResetPasswordActivation
+  ) {
+    return <Navigate to={routes.password.reset} />;
+  }
+
+  if (!onlyUnAuth && !user) {
+    return <Navigate to={routes.signin} state={{ from: location }} />;
+  }
+
+  return component;
+};
+
+export function OnlyUnAuth({ component }: IOnlyUnAuthProps) {
+  return <WithProtectedRoute onlyUnAuth component={component} />;
+}
+
+export const OnlyAuth = WithProtectedRoute;

--- a/src/pages/reset-password-confirmation/reset-password-confirmation.tsx
+++ b/src/pages/reset-password-confirmation/reset-password-confirmation.tsx
@@ -39,7 +39,10 @@ export const ResetPasswordConfirmationPage: FC = (): ReactElement => {
 
     onSubmit: (values, { setSubmitting }) => {
       resetPasswordConfirmation(uid, token, filterFormValues(values))
-        .then(() => setResponseStatus(true))
+        .then(() => {
+          localStorage.removeItem('hasResetPasswordActivation');
+          setResponseStatus(true);
+        })
         .catch(() => setResponseStatus(false))
         .finally(() => setSubmitting(false));
     },
@@ -91,7 +94,7 @@ export const ResetPasswordConfirmationPage: FC = (): ReactElement => {
           heading: 'Пароль успешно изменён',
           buttonLabel: 'Войти в личный кабинет',
           buttonType: 'button',
-          onClick: () => navigate(routes.signin),
+          onClick: () => navigate(routes.signin, { replace: true }),
         };
       case false:
         return {

--- a/src/pages/reset-password/reset-password.tsx
+++ b/src/pages/reset-password/reset-password.tsx
@@ -27,7 +27,13 @@ export const ResetPasswordPage: FC = (): ReactElement => {
 
     onSubmit: (data, { setSubmitting }) => {
       resetPassword(filterFormValues(data))
-        .then(() => setIsSuccess(true))
+        .then(() => {
+          setIsSuccess(true);
+          localStorage.setItem(
+            'hasResetPasswordActivation',
+            JSON.stringify(true)
+          );
+        })
         .catch((err) => {
           serverError = err;
         })
@@ -83,7 +89,7 @@ export const ResetPasswordPage: FC = (): ReactElement => {
       <Button
         label="Вернуться назад"
         model="tertiary"
-        onClick={() => navigate(-1)}
+        onClick={() => navigate(routes.signin)}
       />
     </div>
   );

--- a/src/pages/sign-in/sign-in.tsx
+++ b/src/pages/sign-in/sign-in.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactElement, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'services/app/hooks';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
@@ -15,6 +15,7 @@ import { schemaEmail, schemaPassword } from 'utils/data/validation/yup-schema';
 import styles from './sign-in.module.scss';
 
 const SignInPage: FC = (): ReactElement => {
+  const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -36,7 +37,7 @@ const SignInPage: FC = (): ReactElement => {
 
           if (token) {
             dispatch(getUserPersonalData(token));
-            navigate(routes.profile);
+            navigate(location.state?.from?.pathname || routes.profile);
           }
         })
         .finally(() => setSubmitting(false));
@@ -69,7 +70,7 @@ const SignInPage: FC = (): ReactElement => {
       <Button
         label="Зарегистрироваться"
         model="tertiary"
-        onClick={() => navigate(routes.signup)}
+        onClick={() => navigate(routes.signup, { replace: true })}
       />
     </div>
   );

--- a/src/pages/sign-up-activation/sign-up-activation.tsx
+++ b/src/pages/sign-up-activation/sign-up-activation.tsx
@@ -20,7 +20,10 @@ export const SignUpActivationPage: FC = (): ReactElement => {
 
   useEffect(() => {
     confirmSignUp(uid, token)
-      .then(() => setResponseStatus(true))
+      .then(() => {
+        localStorage.removeItem('hasEmailActivation');
+        setResponseStatus(true);
+      })
       .catch(() => setResponseStatus(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -34,7 +37,7 @@ export const SignUpActivationPage: FC = (): ReactElement => {
           instruction: 'Для продолжения работы войдите в личный кабинет',
           buttonLabel: 'Войти в аккаунт',
           buttonType: 'button',
-          onClick: () => navigate(routes.signin),
+          onClick: () => navigate(routes.signin, { replace: true }),
         };
       case false:
         return {

--- a/src/pages/sign-up/sign-up.tsx
+++ b/src/pages/sign-up/sign-up.tsx
@@ -62,7 +62,10 @@ const SignUpPage: FC = (): ReactElement => {
         registerUser({ ...data, password, re_password: password_confirmation })
       )
         .then((res) => {
-          if (res.type.endsWith('fulfilled')) setIsSuccess(true);
+          if (res.type.endsWith('fulfilled')) {
+            localStorage.setItem('hasEmailActivation', JSON.stringify(true));
+            setIsSuccess(true);
+          }
         })
         .finally(() => setSubmitting(false));
     },

--- a/src/services/features/user/selectors.tsx
+++ b/src/services/features/user/selectors.tsx
@@ -5,4 +5,5 @@ export const isLoading = (state: RootState) => state.user.process.isLoading;
 export const showServerError = (state: RootState) => state.user.process.error;
 
 // USER
+export const isUserAuthChecked = (state: RootState) => state.user.isAuthChecked;
 export const showUserPersonalData = (state: RootState) => state.user;

--- a/src/services/features/user/slice.tsx
+++ b/src/services/features/user/slice.tsx
@@ -4,6 +4,7 @@ import { registerUser, loginUser, getUserPersonalData } from './api';
 
 type TSliceState = {
   user: IUserPersonalData | null;
+  isAuthChecked: boolean;
 
   process: {
     isLoading: boolean;
@@ -13,6 +14,7 @@ type TSliceState = {
 
 const initialState = {
   user: null,
+  isAuthChecked: false,
 
   process: {
     isLoading: false,
@@ -24,6 +26,10 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
+    checkUserAuth(state) {
+      state.isAuthChecked = true;
+    },
+
     resetServerError(state) {
       state.process.error = null;
     },
@@ -72,5 +78,5 @@ const userSlice = createSlice({
   },
 });
 
-export const { resetServerError } = userSlice.actions;
+export const { checkUserAuth, resetServerError } = userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
1) Защитил роуты;
2) На страницы активации email и подтверждения сброса пароля можно попасть исключительно с дополнительным флагом, который хранится в localStorage и удаляется после успешного действия. Можно в принципе заморочиться и написать еще функцию на их автоматическое удаление из хранилища (давай отмашку тогда, но мне кажется, что не имеет особого смысла);
3) Прибрался в App и удалил лишние роуты